### PR TITLE
chore(lock): sync uv.lock humblapi version to 0.20.3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -941,7 +941,7 @@ wheels = [
 
 [[package]]
 name = "humblapi"
-version = "0.19.0"
+version = "0.20.3"
 source = { editable = "." }
 dependencies = [
     { name = "coloredlogs" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Refreshes `uv.lock` after `uv sync` so the editable `humblapi` entry matches `pyproject.toml` (`0.20.3`)
- Bumps lock revision from 2 to 3 (uv tooling metadata)

## Context

Running `pixi run install:all` in humblWORKSPACE exposed that the committed lockfile still pinned `humblapi` at `0.19.0` while `pyproject.toml` was already at `0.20.3`.

## Test plan

- [x] `uv sync` succeeds locally
- [x] No other files changed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d6139da-f5cf-4681-a308-5cc67101abc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d6139da-f5cf-4681-a308-5cc67101abc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

